### PR TITLE
Clean up allure resources after test run, to generate report successfully

### DIFF
--- a/test/specs/parcel.spec.js
+++ b/test/specs/parcel.spec.js
@@ -13,6 +13,12 @@ import {
   validateActionCode,
   validateAvailableArea
 } from '../utils/parcelHelper'
+import { cleanupAllure } from '../utils/allureHelper'
+
+// Add afterAll hook to clean up resources
+afterAll(async () => {
+  await cleanupAllure()
+})
 
 describe('Parcels endpoint', () => {
   it('should validate parcels from CSV data', async () => {

--- a/test/utils/allureHelper.js
+++ b/test/utils/allureHelper.js
@@ -110,9 +110,28 @@ export const allureStep = async (name, fn) => {
   }
 }
 
+/**
+ * Cleanup Allure resources
+ */
+export const cleanupAllure = async () => {
+  try {
+    const allure = getAllure()
+    if (allure) {
+      // Wait for any pending Allure operations to complete
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      // Reset the instance
+      allureInstance = null
+      allureChecked = false
+    }
+  } catch (error) {
+    console.error('Error cleaning up Allure:', error)
+  }
+}
+
 export default {
   getAllure,
   safeAllureCall,
   attachToAllure,
-  allureStep
+  allureStep,
+  cleanupAllure
 }

--- a/test/utils/recordResults.js
+++ b/test/utils/recordResults.js
@@ -5,7 +5,7 @@
  * @param {Object} options - Test options including runAllTests options
  * @returns {Promise<void>} - Resolves when all tests complete, rejects if any test fails
  */
-import { getAllure, safeAllureCall } from './allureHelper.js'
+import { getAllure, safeAllureCall, cleanupAllure } from './allureHelper.js'
 
 export const runTestsAndRecordResults = async (
   dataFile,
@@ -55,6 +55,9 @@ export const runTestsAndRecordResults = async (
       safeAllureCall(allure, 'status', 'failed')
       safeAllureCall(allure, 'description', errorMessage)
     }
+  } finally {
+    // Clean up Allure resources
+    await cleanupAllure()
   }
 
   // Explicitly fail the test if any test cases failed

--- a/test/utils/testRunnerHelper.js
+++ b/test/utils/testRunnerHelper.js
@@ -2,7 +2,8 @@ import {
   getAllure,
   attachToAllure,
   allureStep,
-  safeAllureCall
+  safeAllureCall,
+  cleanupAllure
 } from './allureHelper.js'
 import { readCsv } from './csvReader.js'
 
@@ -147,6 +148,8 @@ export const runAllTests = async (dataFile, testFunction, options = {}) => {
         safeAllureCall(allure, 'status', 'failed')
       }
     }
+    // Clean up Allure resources
+    await cleanupAllure()
   }
   return results
 }


### PR DESCRIPTION
On CI we occasionally see report not getting generated, clearing up allure resources in timely manner should help allure quit and generate report on time.