### PR TITLE
Centralise SFI action versions for stable validation

### DIFF
--- a/test/utils/actionVersions.js
+++ b/test/utils/actionVersions.js
@@ -1,0 +1,73 @@
+/**
+ * Centralised action version source for SFI tests.
+ *
+ * This helper keeps the latest version for each action in one place so tests
+ * can validate if APIs are using the latest config versions. For the explicit
+ * historical "existing application" scenarios, we keep the CSV value so the test
+ * continues to validate the saved action configuration for that case.
+ */
+const LATEST_ACTION_VERSIONS = {
+  CMOR1: '2.0.0',
+  UPL1: '3.1.0',
+  UPL2: '3.1.0',
+  UPL3: '3.1.0',
+  UPL8: '1.0.0',
+  UPL10: '1.0.0',
+  CLIG3: '1.1.0',
+  CSAM3: '1.2.0',
+  SCR2: '1.1.0',
+  CNUM2: '1.0.1',
+  WBD1: '1.0.0'
+}
+
+/**
+ * Decides whether a test case should keep the version from the CSV fixture.
+ *
+ * These are the historical or explicitly configured scenarios where the saved
+ * action version is part of the business expectation, rather than the latest
+ * version in the central map.
+ */
+export function shouldUseCsvVersion(testCase = {}) {
+  const description = String(testCase.TestDescription || '').trim()
+
+  return (
+    description.includes('existing application') ||
+    description.includes('Application with configs provided') ||
+    description.includes(
+      'Application with configs provided for a new application'
+    )
+  )
+}
+
+/**
+ * Returns the expected version for a given action.
+ *
+ * For standard scenarios it uses the latest version. For the explicit
+ * historical configuration cases it keeps the CSV version when one is provided.
+ */
+export function getExpectedActionVersion(
+  actionCode,
+  testCase = {},
+  csvVersion
+) {
+  if (!actionCode) {
+    return csvVersion
+  }
+
+  const normalizedCode = String(actionCode).trim()
+  const explicitVersion =
+    csvVersion === undefined || csvVersion === null || csvVersion === ''
+      ? undefined
+      : String(csvVersion)
+
+  if (shouldUseCsvVersion(testCase) && explicitVersion) {
+    return explicitVersion
+  }
+
+  return String(LATEST_ACTION_VERSIONS[normalizedCode] ?? explicitVersion ?? '')
+}
+
+/**
+ * Exposes the shared action-version map for other helpers and tests.
+ */
+export const ACTION_VERSIONS = LATEST_ACTION_VERSIONS

--- a/test/utils/paymentsHelper.js
+++ b/test/utils/paymentsHelper.js
@@ -1,3 +1,5 @@
+import { getExpectedActionVersion } from './actionVersions.js'
+
 // Helper functions for /payments/calculate endpoint API testing
 /**
  * Validate response status code
@@ -130,8 +132,11 @@ export function validateParcelItems(response, testCase) {
     const expectedParcelItemDurationYears = Number(
       testCase[`parcelItem${parcelItemId}_durationYears`]
     )
-    const expectedParcelItemversion =
+    const expectedParcelItemversion = getExpectedActionVersion(
+      actualItem.code,
+      testCase,
       testCase[`parcelItem${parcelItemId}_version`]
+    )
 
     // Validate parcelItem code for each parcelItemId
     if (actualItem.code !== expectedParcelItemCode) {

--- a/test/utils/validationsHelper.js
+++ b/test/utils/validationsHelper.js
@@ -1,3 +1,5 @@
+import { getExpectedActionVersion } from './actionVersions.js'
+
 // Helper functions for /application/validate and /api/v2/application/validate endpoints API testing
 
 /**
@@ -381,9 +383,22 @@ function assertActionFields(actualAction, expectedAction, path) {
 // Validated caveat fields: code, description.
 // Validated caveat metadata fields (when present): actionCode, sheetId, parcelId, percentageOverlap, overlapAreaHectares.
 // Other fields from API responses (for example explanations) are intentionally ignored.
-function validateExpectedAction(actualAction, expectedAction, path) {
+function validateExpectedAction(
+  actualAction,
+  expectedAction,
+  path,
+  testCase = {}
+) {
+  const expectedVersion = getExpectedActionVersion(
+    actualAction?.actionCode,
+    testCase,
+    expectedAction?.version
+  )
   const normalizedActualAction = normalizeAction(actualAction)
-  const normalizedExpectedAction = normalizeAction(expectedAction)
+  const normalizedExpectedAction = normalizeAction({
+    ...expectedAction,
+    version: expectedVersion
+  })
 
   assertActionFields(normalizedActualAction, normalizedExpectedAction, path)
 }
@@ -414,7 +429,8 @@ export function validateApplicationRules(response, testCase) {
       validateExpectedAction(
         action,
         expectedActions[actionIndex],
-        `actions${actionIndex + 1}`
+        `actions${actionIndex + 1}`,
+        testCase
       )
     })
   } else if (response.status === 400) {


### PR DESCRIPTION
Centralise SFI action versions for stable validation.
To test actions versions.
-For all tests use the latest actions version for assertions if its not an existing application or versions are not passed
-For all existing applications tests, assert against a version from the test data(csv)
-For tests where version provided in the request, assert against a version from the test data(csv)
